### PR TITLE
Use check-exn correctly

### DIFF
--- a/tests/base.rkt
+++ b/tests/base.rkt
@@ -505,7 +505,7 @@
        (check-equal? (->list (drop-when even? (list 1 2 4 3 6))) (list 1 3))
        (check-equal? (->list (drop-when even? #:how-many 2 (list 1 2 4 3 6))) (list 1 3 6))
        (check-exn exn:fail:contract?
-                  (thunk (drop-when (curry = "banana") (set "apple" "banana" "cherry"))) (set "apple" "cherry"))
+                  (thunk (drop-when (curry = "banana") (set "apple" "banana" "cherry"))))
        (check-exn exn:fail:contract?
                   (thunk (drop-when (curry = "BANANA") (generic-set #:key string-upcase "apple" "banana" "cherry"))))))))
 


### PR DESCRIPTION
### Summary of Changes

check-exn accepts two arguments. The third argument is an optional
message, which should be a string. For this particular instance,
it looks like an unintentional left over from copy and paste of
a previous test. So this PR removes the argument.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
